### PR TITLE
Add emulation device support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
   isMultiBrowser: true,
 
   baseBrowsers: ['chromium', 'firefox', 'webkit'],
+  mobileBrowsers: ['chromium', 'webkit'],
 
   async getBrowserList() {
     const browsers = [];
@@ -12,6 +13,9 @@ module.exports = {
     this.baseBrowsers.forEach(browser => {
       browsers.push(browser);
       browsers.push(`${browser}:headless`);
+    });
+
+    this.mobileBrowsers.forEach(browser => {
       Object.keys(playwright.devices).forEach(device => {
         browsers.push(`${browser}:emulation:device=${device}`);
         browsers.push(`${browser}:headless:emulation:device=${device}`);

--- a/index.js
+++ b/index.js
@@ -4,15 +4,21 @@ module.exports = {
 
   isMultiBrowser: true,
 
+  baseBrowsers: ['chromium', 'firefox', 'webkit'],
+
   async getBrowserList() {
-    return [
-      'chromium',
-      'chromium:headless',
-      'firefox',
-      'firefox:headless',
-      'webkit',
-      'webkit:headless',
-    ];
+    const browsers = [];
+
+    this.baseBrowsers.forEach(browser => {
+      browsers.push(browser);
+      browsers.push(`${browser}:headless`);
+      Object.keys(playwright.devices).forEach(device => {
+        browsers.push(`${browser}:emulation:device=${device}`);
+        browsers.push(`${browser}:headless:emulation:device=${device}`);
+      });
+    });
+
+    return browsers;
   },
 
   async isValidBrowserName(browserName) {
@@ -25,9 +31,15 @@ module.exports = {
   },
 
   async openBrowser(id, pageUrl, browserName) {
-    const [browserEngine, runHeadless] = browserName.split(':');
+    const [browserEngine] = browserName.split(':');
+    const runHeadless = browserName.includes('headless');
+    const emulationDeviceMatch = browserName.match("^.+:emulation:device=(?<device>.+)$");
+    let emulationDevice = {}
+    if (emulationDeviceMatch && emulationDeviceMatch.groups && emulationDeviceMatch.groups.device) {
+      emulationDevice = playwright.devices[emulationDeviceMatch.groups.device]
+    }
     const browser = await playwright[browserEngine].launch({ headless: !!runHeadless });
-    const context = await browser.newContext();
+    const context = await browser.newContext({...emulationDevice});
     const page = await context.newPage();
 
     await page.goto(pageUrl);
@@ -41,7 +53,7 @@ module.exports = {
 
   async takeScreenshot(id, screenshotPath) {
     const { page } = this._opened[id];
-    await page.screenshot({ path: screenshotPath });
+    await page.screenshot({ path: screenshotPath, fullPage: true });
   },
 
   async closeBrowser(id) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "testcafe-browser-provider-playwright",
+  "version": "1.0.2",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "testcafe-browser-provider-playwright",
   "version": "1.0.2",
   "description": "playwright TestCafe browser provider plugin.",
-  "keywords": ["testcafe", "browser provider", "plugin"],
+  "keywords": [
+    "testcafe",
+    "browser provider",
+    "plugin"
+  ],
   "repository": "https://github.com/inferpse/testcafe-browser-provider-playwright",
   "homepage": "https://github.com/inferpse/testcafe-browser-provider-playwright",
   "license": "MIT",


### PR DESCRIPTION
This PR adds support for emulation device on Chromium and Webkit, by allowing you to specify browser strings such as `chromium:emulation:device=iPhone X`.  Playwright's device emulation is only supported by Chromium and Webkit.

It also reimplements the headless detection to work with the emulation device string.